### PR TITLE
fix: handle empty content in format function to return a single newline

### DIFF
--- a/crates/beancount-formatter/src/format.rs
+++ b/crates/beancount-formatter/src/format.rs
@@ -378,6 +378,13 @@ pub fn format(path: Option<&str>, source_text: &str, config: &Configuration) -> 
 fn format_content(path: Option<&str>, content: &str, formatting_config: &Configuration) -> Result<String> {
   let path = path.unwrap_or("<memory>");
 
+  if content.trim().is_empty() {
+    return Ok(match formatting_config.new_line {
+      NewLineKind::LF => "\n".to_string(),
+      NewLineKind::CRLF => "\r\n".to_string(),
+    });
+  }
+
   // The parser expects a trailing newline; append one if it's missing.
   let content = if content.ends_with('\n') || content.ends_with("\r\n") {
     content.to_string()

--- a/crates/beancount-formatter/tests/format_cases.rs
+++ b/crates/beancount-formatter/tests/format_cases.rs
@@ -149,3 +149,23 @@ fn format_and_check_fixtures() {
     run_case(&input_path);
   }
 }
+
+#[test]
+fn format_empty_file_is_single_line() {
+  use beancount_formatter::configuration::{Configuration, NewLineKind};
+  use beancount_formatter::format;
+
+  let config = Configuration {
+    new_line: NewLineKind::LF,
+    ..Default::default()
+  };
+  let formatted_lf = format(Some("empty.bean"), "\n\n\t  ", &config).expect("format failed");
+  assert_eq!(formatted_lf, "\n");
+
+  let config = Configuration {
+    new_line: NewLineKind::CRLF,
+    ..Default::default()
+  };
+  let formatted_crlf = format(Some("empty.bean"), "  \r\n\r\n", &config).expect("format failed");
+  assert_eq!(formatted_crlf, "\r\n");
+}


### PR DESCRIPTION
 <!--
close # 
-->
