### PR TITLE
build: always use x64 target as arch

### DIFF
--- a/.github/workflows/_build_wheels.yaml
+++ b/.github/workflows/_build_wheels.yaml
@@ -31,7 +31,6 @@ jobs:
         platform:
           - runner: macos-15
             target: aarch64
-
           - runner: macos-15-intel
             target: x64
 
@@ -41,8 +40,7 @@ jobs:
             target: aarch64
 
           - runner: ubuntu-24.04
-            target: x86_64
-
+            target: x64
           - runner: ubuntu-24.04-arm
             target: aarch64
 


### PR DESCRIPTION
 <!--
close # 
-->
