### PR TITLE
ci: fix wheel artifact artifact download

### DIFF
--- a/.github/workflows/_build_wheels.yaml
+++ b/.github/workflows/_build_wheels.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Upload sdist
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-sdist
+          name: pypi-sdist
           path: dist
 
   wheel:
@@ -73,15 +73,5 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v7
         with:
-          name: wheels-${{ runner.os }}-${{ matrix.platform.target }}
+          name: pypi-wheel-${{ runner.os }}-${{ matrix.platform.target }}
           path: dist
-
-  merge-wheel-artifact:
-    runs-on: ubuntu-24.04
-    needs: ['sdist', 'wheel']
-    steps:
-      - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v7
-        with:
-          name: wheel
-          pattern: wheels-*

--- a/.github/workflows/autofix.yaml
+++ b/.github/workflows/autofix.yaml
@@ -19,7 +19,6 @@ jobs:
         with:
           components: rustfmt,clippy
 
-      - run: cargo fmt || true
       - run: cargo clippy --fix --allow-dirty || true
       - run: cargo fmt || true
       - uses: trim21/actions/prek@master

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -45,7 +45,8 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: wheel
+          pattern: pypi-wheel-*
+          merge-multiple: true
           path: dist
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v8
         with:
-          name: wheel
+          pattern: pypi-*
+          merge-multiple: true
           path: dist
 
       - uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
- Rename wheel/sdist artifacts to pypi-* for consistent matching
- Download artifacts via pattern + merge-multiple in release/tests workflows
- Drop artifact merge job from wheel build
- Run pre-commit after clippy fix in autofix workflow